### PR TITLE
Revert "feat: added an act"

### DIFF
--- a/roles/brew/tasks/_dev.yml
+++ b/roles/brew/tasks/_dev.yml
@@ -2,7 +2,6 @@
   homebrew:
     name:
       - mkcert
-      - nektos/tap/act
       - nss
     state: present
 


### PR DESCRIPTION
This reverts commit 88c948b47910cac6dfe4ebdb9bff9af8c9e2f852.

Fixed an issue that caused the double installation of [act](https://formulae.brew.sh/formula/act).