### PR TITLE
Fixed a bug where the update script would install the latest version of npm that doesn't match Node.js.

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -3,7 +3,6 @@
 
 set -eu
 
-brew update
 brew upgrade
 brew cleanup
 

--- a/bin/update
+++ b/bin/update
@@ -16,10 +16,10 @@ function install_nodejs() {
   LATEST=$(nodenv install -l | grep -e "^${1}\." | tail -n 1 | xargs)
   nodenv install -s "${LATEST}"
   nodenv global "${LATEST}"
-  npm install -g npm@latest
+  npm install -g npm@${2}
   npm upgrade -g
   npm install -g yarn@latest
 }
-install_nodejs 12
-install_nodejs 14
-install_nodejs 15
+install_nodejs 12 6
+install_nodejs 14 6
+install_nodejs 15 7


### PR DESCRIPTION
Using npm v7 with Node.js LTS (v12 or v14) can corrupt the package-lock.json.
The update script specified a default major version that matches the Node.js version to avoid this problem and modified it so that only updates the minor and patch version can apply.