### PR TITLE
Support the ARM and the x86

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,13 +10,13 @@ tap 'homebrew/cask-drivers'
 tap 'homebrew/cask-fonts'
 tap 'homebrew/cask-versions'
 tap 'homebrew/core'
-# tap 'nektos/tap' # ! x86_64?
+tap 'nektos/tap' unless is_m1?
 
 # Audio & Broadcasting
 brew 'ffmpeg'
 cask 'audio-hijack'
 cask 'loopback'
-cask 'obs'
+cask 'obs' unless is_m1? # ! The stable version can't capture the screen correctly with Apple M1.
 cask 'vlc'
 
 # Cloud storages
@@ -48,7 +48,7 @@ cask 'ngrok'
 # Documentations
 brew 'graphviz'
 brew 'mdp'
-# brew 'pandoc' # ! x86_64?
+brew 'pandoc' unless is_m1? # ! x86_64?
 
 # Devices
 cask 'canon-mf-printer'
@@ -56,7 +56,7 @@ cask 'drobo-dashboard'
 cask 'logitech-firmwareupdatetool'
 cask 'logitech-g-hub'
 cask 'logitech-gaming-software'
-# cask 'haptickey' # ! Problem on M1 environment
+cask 'haptickey' unless is_m1? # ! Problem on M1 environment
 
 # Files
 brew 'broot'
@@ -79,7 +79,7 @@ brew 'git'
 brew 'gist'
 brew 'git-lfs'
 brew 'hub'
-# cask 'act' # ! x86_64?
+cask 'act' unless is_m1? # ! x86_64?
 
 # Messaging
 brew 'mmctl'
@@ -120,11 +120,11 @@ cask 'grammarly'
 cask 'notion'
 
 # Virtualizations
-# cask 'docker' # ! Use the technical preview
-# cask 'parallels' # ! Use the technical preview
+cask 'docker' unless is_m1? # ! Use the technical preview
+cask 'parallels' unless is_m1? # ! Use the technical preview
 cask 'vagrant'
-# cask 'virtualbox' # ! x86_64?
-# cask 'virtualbox-extension-pack' # ! x86_64?
+cask 'virtualbox' unless is_m1? # ! x86_64?
+cask 'virtualbox-extension-pack' unless is_m1? # ! x86_64?
 
 # Web browsers
 brew 'links'

--- a/Brewfile
+++ b/Brewfile
@@ -131,6 +131,7 @@ cask 'google-chrome', greedy: true
 # mas 'Developer', id: 640199958
 # mas 'Disk Speed Test', id: 1480068668
 # mas 'GarageBand', id: 682658836
+# mas "GFXBench Metal", id: 1044629456
 # mas 'Grammarly for Safari', id: 1462114288
 # mas 'Human Resource Machine', id: 1005728312
 # mas 'iMovie', id: 408981434
@@ -142,6 +143,7 @@ cask 'google-chrome', greedy: true
 # mas 'Microsoft OneNote', id: 784801555
 # mas 'Microsoft PowerPoint', id: 462062816
 # mas 'Microsoft Remote Desktop', id: 1295203466
+# mas "Microsoft To Do", id: 1274495053
 # mas 'Microsoft Word', id: 462054704
 # mas 'Numbers', id: 409203825
 # mas 'OmniFocus', id: 1474135619
@@ -149,4 +151,5 @@ cask 'google-chrome', greedy: true
 # mas 'Pages', id: 409201541
 # mas 'Remote Desktop', id: 409907375
 # mas 'Slack', id: 803453959
+# mas "Twitter", id: 1482454543
 # mas 'Xcode', id: 497799835

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
+# vim: set ft=ruby :
+
 tap 'homebrew/bundle'
 tap 'homebrew/cask'
 tap 'homebrew/cask-drivers'

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,9 @@
 # vim: set ft=ruby :
 
+def is_m1?
+  !RUBY_PLATFORM.index("arm64e").nil?
+end
+
 tap 'homebrew/bundle'
 tap 'homebrew/cask'
 tap 'homebrew/cask-drivers'

--- a/Brewfile
+++ b/Brewfile
@@ -106,6 +106,7 @@ brew 'thefuck'
 brew 'zsh-completions'
 
 # Signature
+brew 'unbound', restart_service: true
 brew 'gnupg'
 brew 'pinentry-mac'
 

--- a/Brewfile
+++ b/Brewfile
@@ -135,12 +135,12 @@ cask 'google-chrome'
 # mas 'Kindle', id: 405399194
 # mas 'LINE', id: 539883307
 # mas 'Messenger', id: 1480068668
-# mas 'Numbers', id: 409203825
 # mas 'Microsoft Excel', id: 462058435
 # mas 'Microsoft OneNote', id: 784801555
 # mas 'Microsoft PowerPoint', id: 462062816
 # mas 'Microsoft Remote Desktop', id: 1295203466
 # mas 'Microsoft Word', id: 462054704
+# mas 'Numbers', id: 409203825
 # mas 'OmniFocus', id: 1474135619
 # mas 'OneDrive', id: 823766827
 # mas 'Pages', id: 409201541

--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,7 @@ tap 'homebrew/bundle'
 tap 'homebrew/cask'
 tap 'homebrew/cask-drivers'
 tap 'homebrew/cask-fonts'
+tap 'homebrew/cask-versions'
 tap 'homebrew/core'
 # tap 'nektos/tap' # ! x86_64?
 
@@ -76,7 +77,7 @@ brew 'hub'
 
 # Messaging
 brew 'mmctl'
-cask 'discord'
+cask 'discord-ptb'
 cask 'mattermost'
 cask 'keybase'
 cask 'skype'

--- a/Brewfile
+++ b/Brewfile
@@ -30,7 +30,7 @@ cask 'adoptopenjdk'
 brew 'vim'
 cask 'atom'
 cask 'sublime-text'
-cask 'visual-studio-code'
+cask 'visual-studio-code', greedy: true
 
 # Development: for Mobile apps
 cask 'android-studio'
@@ -124,7 +124,7 @@ cask 'vagrant'
 # Web browsers
 brew 'links'
 cask 'firefox'
-cask 'google-chrome'
+cask 'google-chrome', greedy: true
 
 # mas
 # mas 'Cinebench', id: 1438772273

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 #### Messaging
 
-- [Discord](https://discord.com)
+- [Discord Public Test Build](https://discord.com)
 - [Mattermost / with CLI tools](https://mattermost.com)
 - [Keybase](https://keybase.io)
 - [Microsoft Skype](https://www.skype.com/)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Unless otherwise specified, as a general rule, install via Homebrew.
 <!-- markdownlint-disable MD033 -->
 <details><summary>CLI Apps</summary>
 
+| note | description          |
+| :--: | :------------------- |
+| `-M` | without M1 Processor |
+
 #### Audio
 
 - [FFmpeg](https://www.ffmpeg.org)
@@ -68,6 +72,7 @@ Unless otherwise specified, as a general rule, install via Homebrew.
 
 #### Version control system
 
+- `(-M)` [act](https://github.com/nektos/act)
 - [Git](https://git-scm.com)
 - [Gist](http://defunkt.io/gist/)
 - [Git Large File Storage](https://git-lfs.github.com)
@@ -119,11 +124,16 @@ Unless otherwise specified, as a general rule, install via Homebrew.
 Apps that exist in the Mac App Store are temporarily not installed by this script. It's because the installation is unstable and very slow.  
 Mac App Store からインストール可能なアプリは、このスクリプトでは暫定的にインストールしないようにしています。インストールが不安定かつ非常に低速となるためです。
 
+| note | description          |
+| :--: | :------------------- |
+| `-M` | without M1 Processor |
+
 #### Audio & Broadcasting
 
 - [Rogue Amoeba Audio Hijack](https://rogueamoeba.com/audiohijack/)
 - [Rogue Amoeba Loopback](https://rogueamoeba.com/loopback/)
-- [OBS Studio](https://obsproject.com/)
+- `(-M)` [OBS Studio](https://obsproject.com/)
+  - The stable version can't capture the screen correctly with Apple M1.
 - [VLC Player](https://obsproject.com/)
 
 #### Cloud storages
@@ -142,7 +152,10 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 #### Devices
 
+- [Canon Satera MF Printer driver](https://cweb.canon.jp/satera/mfp/)
 - [Drobo Dashboard](https://www.drobo.com/)
+- `(-M)` [HapticKey](https://github.com/niw/HapticKey)
+- [logicool G Hub](https://gaming.logicool.co.jp/ja-jp/innovation/g-hub.html)
 
 #### Games
 
@@ -172,6 +185,12 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 - [terminal-notifier](https://github.com/julienXX/terminal-notifier)
 
+#### Virtualizations
+
+- `(-M)` [Docker Desktop](https://www.docker.com/products/docker-desktop)
+- `(-M)` [Parallels Desktop](https://www.parallels.com/)
+- `(-M)` [Oracle VM Virtualbox + Extension Pack](https://www.virtualbox.org)
+
 #### Web browsers
 
 - [Google Chrome](https://www.google.com/intl/ja_jp/chrome/)
@@ -192,7 +211,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 ### Install the upgrade script
 
-一つのコマンドだけで、インストールしたアプリをアップグレードするスクリプトをインストールします。
+ひとつのコマンドだけで、インストールしたアプリをアップグレードするスクリプトをインストールします。
 
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD033 -->
@@ -216,7 +235,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 The script creates a symbolic link to the Prezto default profile.
 Also, add a definition so that you can scan under the `~/.zsh.d` folder when starting the interactive shell.  
 セットアップ スクリプトは Prezto 既定のプロファイルへシンボリックリンクを作成します。
-同時に対話シェル開始時に `~/.zsh.d` フォルダ配下をスキャンできるように定義を追加しています。
+同時に、対話シェル開始時に `~/.zsh.d` フォルダ配下をスキャンできるよう定義を追加しています。
 
 ### Initialize for web-frontend development environment
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Unless otherwise specified, as a general rule, install via Homebrew.
 
 - [GnuPG: The GNU Privacy Guard](https://gnupg.org)
 - [PINEntry for Mac](https://github.com/GPGTools/pinentry)
+- [Unbound](https://www.nlnetlabs.nl/projects/unbound/)
 
 #### Virtualizations
 

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -10,14 +10,14 @@ tap 'homebrew/cask-drivers'
 tap 'homebrew/cask-fonts'
 tap 'homebrew/cask-versions'
 tap 'homebrew/core'
-# tap 'nektos/tap' # ! x86_64?
+tap 'nektos/tap' unless is_m1?
 
 # Audio & Broadcasting
 brew 'ffmpeg'
 cask 'audio-hijack'
 cask 'loopback'
-cask 'obs'
-# cask 'vlc'
+cask 'obs' unless is_m1? # ! The stable version can't capture the screen correctly with Apple M1.
+cask 'vlc'
 
 # Cloud storages
 # cask 'adobe-creative-cloud'
@@ -48,7 +48,7 @@ cask 'ngrok'
 # Documentations
 brew 'graphviz'
 brew 'mdp'
-# brew 'pandoc' # ! x86_64?
+brew 'pandoc' unless is_m1? # ! x86_64?
 
 # Devices
 # cask 'canon-mf-printer'
@@ -56,7 +56,7 @@ brew 'mdp'
 # cask 'logitech-firmwareupdatetool'
 # cask 'logitech-g-hub'
 # cask 'logitech-gaming-software'
-# cask 'haptickey' # ! Problem on M1 environment
+# cask 'haptickey' unless is_m1? # ! Problem on M1 environment
 
 # Files
 brew 'broot'
@@ -79,7 +79,7 @@ brew 'git'
 brew 'gist'
 brew 'git-lfs'
 brew 'hub'
-# cask 'act' # ! x86_64?
+cask 'act' unless is_m1? # ! x86_64?
 
 # Messaging
 brew 'mmctl'
@@ -120,11 +120,11 @@ cask 'grammarly'
 cask 'notion'
 
 # Virtualizations
-# cask 'docker' # ! Use the technical preview
-# cask 'parallels' # ! Use the technical preview
+cask 'docker' unless is_m1? # ! Use the technical preview
+cask 'parallels' unless is_m1? # ! Use the technical preview
 cask 'vagrant'
-# cask 'virtualbox' # ! x86_64?
-# cask 'virtualbox-extension-pack' # ! x86_64?
+cask 'virtualbox' unless is_m1? # ! x86_64?
+cask 'virtualbox-extension-pack' unless is_m1? # ! x86_64?
 
 # Web browsers
 brew 'links'

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -18,7 +18,6 @@ cask 'obs'
 cask 'omnipresence'
 
 # Development
-brew 'ansible'
 brew 'gcc'
 brew 'jq'
 brew 'pict'
@@ -26,8 +25,8 @@ cask 'adoptopenjdk'
 
 # Development: IDE
 brew 'vim'
-# cask 'atom'
-# cask 'sublime-text'
+cask 'atom'
+cask 'sublime-text'
 cask 'visual-studio-code'
 
 # Development: for Mobile apps
@@ -45,7 +44,11 @@ brew 'mdp'
 # brew 'pandoc' # ! x86_64?
 
 # Devices
+# cask 'canon-mf-printer'
 # cask 'drobo-dashboard'
+# cask 'logitech-firmwareupdatetool'
+# cask 'logitech-g-hub'
+# cask 'logitech-gaming-software'
 # cask 'haptickey' # ! Problem on M1 environment
 
 # Files
@@ -69,7 +72,7 @@ brew 'git'
 brew 'gist'
 brew 'git-lfs'
 brew 'hub'
-# brew 'nektos/tap/act' # ! x86_64?
+# cask 'act' # ! x86_64?
 
 # Messaging
 brew 'mmctl'
@@ -132,12 +135,12 @@ cask 'google-chrome'
 # # mas 'Kindle', id: 405399194
 # # mas 'LINE', id: 539883307
 # # mas 'Messenger', id: 1480068668
-# mas 'Numbers', id: 409203825
 # # mas 'Microsoft Excel', id: 462058435
 # # mas 'Microsoft OneNote', id: 784801555
 # # mas 'Microsoft PowerPoint', id: 462062816
 # # mas 'Microsoft Remote Desktop', id: 1295203466
 # # mas 'Microsoft Word', id: 462054704
+# mas 'Numbers', id: 409203825
 # mas 'OmniFocus', id: 1474135619
 # mas 'OneDrive', id: 823766827
 # mas 'Pages', id: 409201541

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -1,3 +1,5 @@
+# vim: set ft=ruby :
+
 tap 'homebrew/bundle'
 tap 'homebrew/cask'
 tap 'homebrew/cask-drivers'

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -1,5 +1,9 @@
 # vim: set ft=ruby :
 
+def is_m1?
+  !RUBY_PLATFORM.index("arm64e").nil?
+end
+
 tap 'homebrew/bundle'
 tap 'homebrew/cask'
 tap 'homebrew/cask-drivers'

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -30,7 +30,7 @@ cask 'adoptopenjdk'
 brew 'vim'
 cask 'atom'
 cask 'sublime-text'
-cask 'visual-studio-code'
+cask 'visual-studio-code', greedy: true
 
 # Development: for Mobile apps
 # cask 'android-studio'
@@ -123,8 +123,8 @@ cask 'vagrant'
 
 # Web browsers
 brew 'links'
-cask 'firefox'
-cask 'google-chrome'
+cask 'firefox', greedy: true
+cask 'google-chrome', greedy: true
 
 # mas
 # mas 'Cinebench', id: 1438772273

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -106,6 +106,7 @@ brew 'thefuck'
 brew 'zsh-completions'
 
 # Signature
+brew 'unbound', restart_service: true
 brew 'gnupg'
 brew 'pinentry-mac'
 

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -131,6 +131,7 @@ cask 'google-chrome', greedy: true
 # mas 'Developer', id: 640199958
 # mas 'Disk Speed Test', id: 1480068668
 # # mas 'GarageBand', id: 682658836
+# mas "GFXBench Metal", id: 1044629456
 # mas 'Grammarly for Safari', id: 1462114288
 # # mas 'Human Resource Machine', id: 1005728312
 # # mas 'iMovie', id: 408981434
@@ -142,6 +143,7 @@ cask 'google-chrome', greedy: true
 # # mas 'Microsoft OneNote', id: 784801555
 # # mas 'Microsoft PowerPoint', id: 462062816
 # # mas 'Microsoft Remote Desktop', id: 1295203466
+# # mas "Microsoft To Do", id: 1274495053
 # # mas 'Microsoft Word', id: 462054704
 # mas 'Numbers', id: 409203825
 # mas 'OmniFocus', id: 1474135619
@@ -149,4 +151,5 @@ cask 'google-chrome', greedy: true
 # mas 'Pages', id: 409201541
 # # mas 'Remote Desktop', id: 409907375
 # mas 'Slack', id: 803453959
+# # mas "Twitter", id: 1482454543
 # mas 'Xcode', id: 497799835

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -2,6 +2,7 @@ tap 'homebrew/bundle'
 tap 'homebrew/cask'
 tap 'homebrew/cask-drivers'
 tap 'homebrew/cask-fonts'
+tap 'homebrew/cask-versions'
 tap 'homebrew/core'
 # tap 'nektos/tap' # ! x86_64?
 
@@ -76,7 +77,7 @@ brew 'hub'
 
 # Messaging
 brew 'mmctl'
-# cask 'discord'
+# cask 'discord-ptb'
 cask 'mattermost'
 cask 'keybase'
 # cask 'skype'


### PR DESCRIPTION
This update is a Brewfile and documentation-only update.

- Added the installing apps
  - Until now, we have listed only the apps that can use with both M1 and intel, but by introducing the automatic detection function, we have also listed the apps that support only one.
- Added a "greedy" option to some apps
