### PR TITLE
Some app installations will remove on Apple Silicon based Mac

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -109,7 +109,7 @@ cask 'schism-tracker'
 cask 'sonic-visualiser'
 
 # Authentication
-cask 'authy'
+cask 'authy' unless is_arm? # Install from Mac App Store
 cask 'keybase' unless is_arm? # Install from Mac App Store
 
 # Desktop
@@ -148,7 +148,7 @@ cask 'steamcmd'
 
 # Messaging
 cask 'discord'
-cask 'gitter'
+cask 'gitter' unless is_arm? # Install from Mac App Store
 cask 'google-chat'
 cask 'skype'
 cask 'zoom', greedy: true
@@ -166,7 +166,7 @@ cask 'adoptopenjdk'
 cask 'powershell'
 
 # Tasks & Memos
-cask 'boost-note'
+cask 'boost-note' unless is_arm? # Install from Mac App Store
 cask 'grammarly'
 cask 'notion'
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 #### Authentication
 
-- [Authy Desktop](https://authy.com/download/)
+- `(-A)` [Authy Desktop](https://authy.com/download/)
 - `(-A)` [Keybase](https://keybase.io/)
   - Keybase app is distributed only Apple Sillicon Mac in the Mac App Store.
 
@@ -303,7 +303,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 #### Memos and Tasks
 
-- [Boost Note](https://boostnote.io/)
+- `(-A)` [Boost Note](https://boostnote.io/)
 - [Grammarly](https://www.grammarly.com/)
 - [Microsoft To Do](https://todo.microsoft.com/) (via Mac App Store)
 - [Notion](https://www.notion.so/)
@@ -313,7 +313,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 - [Discord](https://discord.com/)
 - [Facebook Messenger](https://www.messenger.com/) (via Mac App Store)
-- [Gitter](https://gitter.im/)
+- `(-A)` [Gitter](https://gitter.im/)
 - [Google Chat](https://workspace.google.co.jp/products/chat/)
 - [LINE](https://line.me/) (via Mac App Store)
 - [Microsoft Skype](https://www.skype.com/)

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -109,7 +109,7 @@ mas 'OneDrive', id: 823766827
 # cask 'sonic-visualiser'
 
 # Authentication
-cask 'authy'
+cask 'authy' unless is_arm? # Install from Mac App Store
 cask 'keybase' unless is_arm? # Install from Mac App Store
 
 # Desktop
@@ -148,7 +148,7 @@ cask 'steamcmd'
 
 # Messaging
 # cask 'discord'
-cask 'gitter'
+cask 'gitter' unless is_arm? # Install from Mac App Store
 # cask 'google-chat'
 # cask 'skype'
 cask 'zoom', greedy: true
@@ -166,7 +166,7 @@ cask 'adoptopenjdk'
 cask 'powershell'
 
 # Tasks & Memos
-cask 'boost-note'
+cask 'boost-note' unless is_arm? # Install from Mac App Store
 cask 'grammarly'
 cask 'notion'
 


### PR DESCRIPTION
If you wish to use the following apps, please install them from the Mac App Store:

- [Authy Desktop](https://authy.com/download/)
- [Boost Note](https://boostnote.io/)
- [Gitter](https://gitter.im/)

In the future, we would like to use the [mas-cli](https://github.com/mas-cli/mas) app to automate installation from the Mac App Store.