### PR TITLE
Cumulative updates include that adds some app installation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
     "cloc",
     "coreutils",
     "dind",
-    "drobo",
+    "forti",
     "gotop",
     "groff",
     "imager",

--- a/Brewfile
+++ b/Brewfile
@@ -157,6 +157,7 @@ cask 'zoom', greedy: true
 
 # Remote tools
 cask 'amazon-workspaces'
+cask 'forticlient-vpn'
 cask 'ngrok'
 cask 'teamviewer'
 cask 'vnc-viewer'

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 - [Amazon Workspaces](https://clients.amazonworkspaces.com/)
 - [Apple Remote Desktop](http://www.apple.com/remotedesktop/) (via Mac App Store)
+- [FortiClient VPN](https://www.fortinet.com/products/endpoint-security/forticlient)
 - [Microsoft Remote Desktop](https://apps.apple.com/app/microsoft-remote-desktop/id1295203466) (via Mac App Store)
 - [Real VNC Viewer](https://www.realvnc.com/connect/download/viewer/)
 - [TeamViewer](https://www.teamviewer.com/)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Unless otherwise specified, as a general rule, install via Homebrew or Cask.
     - [Node.js](https://nodejs.org/) (via asdf-nodejs)
       - v14 LTS Fermium
       - v16 LTS Gallium
-      - v18
+      - v18 LTS Hydrogen
+      - v19
   - plugin: [asdf-python](https://github.com/danhper/asdf-python) (via asdf)
     - [Python](https://www.python.org) (via asdf-python)
       - v2

--- a/bin/update_asdf
+++ b/bin/update_asdf
@@ -42,7 +42,7 @@ install_nodejs_deps() {
 
   npm install -g --silent npm@"${1}"
   npm upgrade -g --silent
-  npm install -g --silent yarn@berry
+  npm install -g --silent yarn
 }
 
 remove_obsolete_nodejs_versions() {

--- a/bin/update_asdf
+++ b/bin/update_asdf
@@ -82,7 +82,8 @@ install_nodejs 14 6
 install_nodejs lts-fermium 6
 install_nodejs 16 8
 install_nodejs lts-gallium 8
-install_nodejs lts 8
 install_nodejs 18 8
+install_nodejs lts-hydrogen 8
+install_nodejs lts 8
 install_nodejs 19 8
 install_nodejs latest 8

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -157,6 +157,7 @@ cask 'zoom', greedy: true
 
 # Remote tools
 cask 'amazon-workspaces'
+# cask 'forticlient-vpn'
 cask 'ngrok'
 # cask 'teamviewer'
 cask 'vnc-viewer'


### PR DESCRIPTION
- Added some apps installation
  - [FortiClient VPN](https://www.fortinet.com/products/endpoint-security/forticlient) (01bf41e)
  - [Node.js](https://nodejs.org/) v18 as the “LTS Hydrogen” (0a08a44)
- Degraded the version of Yarn to be installed to v1. (69b080c)
  - If you are using Yarn 1.18.0 or later, it will automatically recognize the version designation and use the specified version.
