### PR TITLE
Cumulative updates contain that added the Node.js v20 installation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,6 @@
     "cloc",
     "coreutils",
     "dind",
-    "forti",
     "gotop",
     "groff",
     "imager",

--- a/Brewfile
+++ b/Brewfile
@@ -158,7 +158,6 @@ cask 'zoom', greedy: true
 
 # Remote tools
 cask 'amazon-workspaces'
-cask 'forticlient-vpn'
 cask 'ngrok'
 cask 'teamviewer'
 cask 'vnc-viewer'

--- a/README.md
+++ b/README.md
@@ -327,7 +327,6 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 
 - [Amazon Workspaces](https://clients.amazonworkspaces.com/)
 - [Apple Remote Desktop](http://www.apple.com/remotedesktop/) (via Mac App Store)
-- [FortiClient VPN](https://www.fortinet.com/products/endpoint-security/forticlient)
 - [Microsoft Remote Desktop](https://apps.apple.com/app/microsoft-remote-desktop/id1295203466) (via Mac App Store)
 - [Real VNC Viewer](https://www.realvnc.com/connect/download/viewer/)
 - [TeamViewer](https://www.teamviewer.com/)

--- a/bin/update
+++ b/bin/update
@@ -11,7 +11,10 @@ while true; do sleep 50; sudo -n true; kill -0 "$$" || exit; done 2>/dev/null &
 brew upgrade
 brew cleanup
 
-vagrant plugin update
+if which vagrant > /dev/null 2>&1
+then
+  vagrant plugin update
+fi
 
 ./update_docker
 

--- a/bin/update_asdf
+++ b/bin/update_asdf
@@ -38,11 +38,13 @@ install_nodejs_deps() {
   . "${HOME}/.zsh.d/z-asdf"
 
   # https://qiita.com/Qoo_Rus/items/afb52517e0e17b720990
+  npm uninstall -g --silent yarn
   npm install -g --silent agentkeepalive@latest
 
   npm install -g --silent npm@"${1}"
   npm upgrade -g --silent
-  npm install -g --silent yarn
+  corepack enable
+  asdf reshim
 }
 
 remove_obsolete_nodejs_versions() {

--- a/bin/update_asdf
+++ b/bin/update_asdf
@@ -84,8 +84,9 @@ install_nodejs 14 6
 install_nodejs lts-fermium 6
 install_nodejs 16 8
 install_nodejs lts-gallium 8
-install_nodejs 18 8
-install_nodejs lts-hydrogen 8
-install_nodejs lts 8
-install_nodejs 19 8
-install_nodejs latest 8
+install_nodejs 18 9
+install_nodejs lts-hydrogen 9
+install_nodejs lts 9
+install_nodejs 19 9
+install_nodejs latest 9
+install_nodejs 20 9

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -158,7 +158,6 @@ cask 'zoom', greedy: true
 
 # Remote tools
 cask 'amazon-workspaces'
-# cask 'forticlient-vpn'
 cask 'ngrok'
 # cask 'teamviewer'
 cask 'vnc-viewer'


### PR DESCRIPTION
- added the Node.js and npm version
  - Node.js v20 (Added)
  - Node.js v18-19: npm v8 -> v9
- enabled updaters to be run in environments where vagrant is not installed
- removed an app: [FortiClient VPN](https://www.fortinet.com/products/endpoint-security/forticlient)
