### PR TITLE
Maintenance update includes fixes the Node.js LTS alias installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.toptal.com/developers/gitignore/api/homebrew,linux,macos,sublimetext,vagrant,vim,visualstudiocode,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=homebrew,linux,macos,sublimetext,vagrant,vim,visualstudiocode,windows
 
@@ -134,12 +133,6 @@ tags
 # Ignore all local history of files
 .history
 .ionide
-
-# Support for Project snippet scope
-.vscode/*.code-snippets
-
-# Ignore code-workspaces
-*.code-workspace
 
 ### Windows ###
 # Windows thumbnail cache files

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,9 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/homebrew,linux,macos,sublimetext,vagrant,vim,visualstudiocode,windows
+
+
+### THE PROJECT SPECIFIES #################################################
+
+### CSpell ###
+.cspell.cache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,46 +1,4 @@
 {
-  "cSpell.ignorePaths": [
-    ".git/objects",
-    ".github/CODE_OF_CONDUCT.*",
-    ".vscode"
-  ],
-  "cSpell.words": [
-    "antlr",
-    "authy",
-    "awscli",
-    "broot",
-    "cloc",
-    "coreutils",
-    "dind",
-    "gotop",
-    "groff",
-    "imager",
-    "inetutils",
-    "iZotope",
-    "Karabiner",
-    "kito",
-    "kurone",
-    "lato",
-    "logicool",
-    "lporg",
-    "mackup",
-    "maxon",
-    "meslo",
-    "mkcert",
-    "nmap",
-    "nyancat",
-    "omni",
-    "pfind",
-    "pgrep",
-    "pkill",
-    "plex",
-    "prezto",
-    "scrcpy",
-    "tldr",
-    "vbguest",
-    "visualiser",
-    "wkhtmltopdf"
-  ],
   "files.watcherExclude": {
     "**/.vagrant": true
   }

--- a/Brewfile
+++ b/Brewfile
@@ -112,9 +112,6 @@ cask 'sonic-visualiser'
 cask 'authy' unless is_arm? # Install from Mac App Store
 cask 'keybase' unless is_arm? # Install from Mac App Store
 
-# Desktop
-cask 'avibrazil-rdm'
-
 # Development
 cask 'anatawa12/cask/vcc-for-mac'
 cask 'dotnet-sdk'
@@ -151,7 +148,6 @@ cask 'steamcmd'
 # Messaging
 cask 'discord'
 cask 'gitter' unless is_arm? # Install from Mac App Store
-cask 'google-chat'
 cask 'microsoft-teams'
 cask 'skype'
 cask 'zoom', greedy: true

--- a/README.md
+++ b/README.md
@@ -254,10 +254,6 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 - [Microsoft OneDrive](https://www.microsoft.com/microsoft-365/onedrive)
 - [OmniPresence](https://www.omnigroup.com/more)
 
-#### Desktop
-
-- [RDM](https://github.com/avibrazil/RDM)
-
 #### Development
 
 - [Android Studio](https://developer.android.com/studio)
@@ -273,7 +269,7 @@ Mac App Store からインストール可能なアプリは、このスクリプ
     - Module: Windows Build Support (Mono)
     - Module: Documentation
     - Module: Language Pack (Japanese)
-- [VRChat Creator Companion](https://github.com/AranoYuki1/VCC-for-mac)
+- [VCC for mac](https://github.com/AranoYuki1/VCC-for-mac)
 
 #### Devices
 
@@ -315,7 +311,6 @@ Mac App Store からインストール可能なアプリは、このスクリプ
 - [Discord](https://discord.com/)
 - [Facebook Messenger](https://www.messenger.com/) (via Mac App Store)
 - `(-A)` [Gitter](https://gitter.im/)
-- [Google Chat](https://workspace.google.co.jp/products/chat/)
 - [LINE](https://line.me/) (via Mac App Store)
 - [Microsoft Skype](https://www.skype.com/)
 - [Microsoft Teams](https://www.microsoft.com/ja-jp/microsoft-teams/group-chat-software)

--- a/bin/update_asdf
+++ b/bin/update_asdf
@@ -80,13 +80,13 @@ install_nodejs() {
   set -e
 }
 
-install_nodejs 14 6
-install_nodejs lts-fermium 6
+export ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY=latest_installed
+
 install_nodejs 16 8
 install_nodejs lts-gallium 8
 install_nodejs 18 9
 install_nodejs lts-hydrogen 9
 install_nodejs lts 9
 install_nodejs 19 9
-install_nodejs latest 9
 install_nodejs 20 9
+install_nodejs latest 9

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -1,0 +1,77 @@
+$schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+cache:
+  cacheFormat: universal
+  cacheLocation: .cspell.cache
+  cacheStrategy: metadata
+  useCache: true
+dictionaries:
+  - bash
+  - companies
+  - cpp
+  - cpp-legacy
+  - en-gb
+  - en_us
+  - fonts
+  - git
+  - npm
+  - softwareTerms
+language: en,ja
+languageSettings:
+  - allowCompoundWords: true
+    caseSensitive: false
+    enabled: true
+    languageId: "*"
+    locale: en,ja
+ignorePaths:
+  - .git/objects
+  - .github/CODE_OF_CONDUCT.*
+  - cspell.config.yml
+ignoreWords:
+  - alsa
+  - antlr
+  - apic
+  - authy
+  - biosapic
+  - bioslogofadein
+  - broot
+  - cfprefsd
+  - clmv
+  - dind
+  - glab
+  - gotop
+  - hpet
+  - hwvirtex
+  - ioapic
+  - ionescu
+  - iZotope
+  - karabiner
+  - kito
+  - kotoeri
+  - kurone
+  - lporg
+  - mackup
+  - maxon
+  - meslo
+  - modifyvm
+  - mswin
+  - nmap
+  - nyancat
+  - osascript
+  - pfind
+  - pgrep
+  - pkill
+  - plantUML
+  - siri
+  - sorin
+  - spctl
+  - usbxhci
+  - TextQL
+  - tldr
+  - usbxhci
+  - vbguest
+  - vtxux
+  - vtxvpid
+  - wkhtmltopdf
+  - zprezto
+useGitignore: true
+version: "0.2"

--- a/libs/docker.sh
+++ b/libs/docker.sh
@@ -39,20 +39,24 @@ docker pull ubuntu
 docker pull docker
 docker pull docker:dind
 docker pull docker:git
-docker pull node:14
-docker pull node:14-alpine
-docker pull node:14-bullseye-slim
 docker pull node:16
 docker pull node:16-alpine
 docker pull node:16-bullseye-slim
 docker pull node:18
 docker pull node:18-alpine
 docker pull node:18-slim
+docker pull node:19
+docker pull node:19-alpine
+docker pull node:19-slim
+docker pull node:20
+docker pull node:20-alpine
+docker pull node:20-slim
 docker pull gitlab/gitlab-runner
+docker pull ghcr.io/catthehacker/ubuntu:act-20.04
 docker pull ghcr.io/catthehacker/ubuntu:act-22.04
 docker pull ghcr.io/catthehacker/ubuntu:act-latest
 
-# ! Commented out because the container is too lerge!
+# ! Commented out because the container is too large!
 # docker pull ghcr.io/catthehacker/ubuntu:full-20.04
 # docker pull ghcr.io/catthehacker/ubuntu:full-latest
 

--- a/libs/prezto.sh
+++ b/libs/prezto.sh
@@ -10,8 +10,8 @@ log_info 'Installing the Prezto'
 wait_dependencies git zsh
 
 github_clone_if_not_exists sorin-ionescu/prezto "${ZDOTDIR:-$HOME}/.zprezto"
-RCFILES=$(find "${ZDOTDIR:-$HOME}"/.zprezto/runcoms -type f -name 'z*')
-for rcfile in ${RCFILES}
+FILES=$(find "${ZDOTDIR:-$HOME}"/.zprezto/runcoms -type f -name 'z*')
+for file in ${FILES}
 do
-  ln -snf "${rcfile}" "${ZDOTDIR:-$HOME}/.${rcfile##*/}"
+  ln -snf "${file}" "${ZDOTDIR:-$HOME}/.${file##*/}"
 done

--- a/libs/updaters.sh
+++ b/libs/updaters.sh
@@ -5,7 +5,7 @@ cd "$(cd "$(dirname "$0")"; pwd)"
 
 . lib.sh
 
-log_info 'Installing the updators.'
+log_info 'Installing the updaters.'
 
 # Update scripts
 mkdir -p "${HOME}/bin"

--- a/min.Brewfile
+++ b/min.Brewfile
@@ -112,9 +112,6 @@ mas 'OneDrive', id: 823766827
 cask 'authy' unless is_arm? # Install from Mac App Store
 cask 'keybase' unless is_arm? # Install from Mac App Store
 
-# Desktop
-cask 'avibrazil-rdm'
-
 # Development
 # cask 'anatawa12/cask/vcc-for-mac'
 cask 'dotnet-sdk'
@@ -151,7 +148,6 @@ cask 'steamcmd'
 # Messaging
 # cask 'discord'
 cask 'gitter' unless is_arm? # Install from Mac App Store
-# cask 'google-chat'
 # cask 'microsoft-teams'
 # cask 'skype'
 cask 'zoom', greedy: true


### PR DESCRIPTION
## Features

- 158c4e9: removed some apps installation
  - ~~[Google Chat](https://workspace.google.co.jp/products/chat/)~~
  - ~~[RDM](https://github.com/avibrazil/RDM)~~
- 0e8e285: added and removed some Docker images pulling
  - ~~`node:14`, `14-alpine`, `14-bullseye-slim`~~
  - `node:19`, `14-alpine`, `14-slim`
  - `node:20`, `20-alpine`, `20-slim`
  - `ghcr.io/catthehacker/ubuntu:act-20.04`

## Bug Fixes

- 8ea392f: fixed the bug that fails the Node.js LTS alias installation
- e9f1235: improved the spelling

## Others updates

- 99ad575: added the CSpell configuration to the project
- eb3a1cd: improved the gitignore configuration
